### PR TITLE
Do not disable open_sessions after failure

### DIFF
--- a/winauthenticator/winauthenticator.py
+++ b/winauthenticator/winauthenticator.py
@@ -175,8 +175,6 @@ class WinAuthenticator(LocalAuthenticator):
             win32profile.UnloadUserProfile(token, self._hreg)
         except Exception as exc:
             self.log.warning("Failed to unload user profile for %s: %s", user.name, exc)
-            self.log.warning("Disabling user profile from now on.")
-            self.open_sessions = False
         finally:
             if token:
                 # Detach so token stays valid

--- a/winauthenticator/winauthenticator.py
+++ b/winauthenticator/winauthenticator.py
@@ -35,7 +35,7 @@ class WinAuthenticator(LocalAuthenticator):
 
     domain_to_add_to_username = Unicode("",
                          help="""
-        Domain to add to the username typed in the login form. If empty, nothing will be added.
+        Domain to add to the username, as if typed in the login form. If empty, nothing will be added.
         """
                         ).tag(config=True)
 

--- a/winauthenticator/winauthenticator.py
+++ b/winauthenticator/winauthenticator.py
@@ -1,7 +1,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from tornado.concurrent import run_on_executor
-from traitlets import default, Any, Bool
+from traitlets import default, Any, Bool, Unicode
 
 from jupyterhub.auth import LocalAuthenticator, Authenticator
 from jupyterhub.utils import maybe_future
@@ -33,6 +33,11 @@ class WinAuthenticator(LocalAuthenticator):
         """
                         ).tag(config=True)
 
+    domain_to_add_to_username = Unicode("",
+                         help="""
+        Domain to add to the username typed in the login form. If empty, nothing will be added.
+        """
+                        ).tag(config=True)
 
     @default('add_user_cmd')
     def _add_user_cmd_default(self):
@@ -92,9 +97,13 @@ class WinAuthenticator(LocalAuthenticator):
         Return None otherwise.
         """
         domain = '.'
+
+        if self.domain_to_add_to_username:
+            if not '@' in data['username']:
+                data['username'] += "@" + self.domain_to_add_to_username
         username = data['username']
 
-        if '@' in data['username']:
+        if '@' in username:
             username, domain = username.split('@')
 
         try:
@@ -113,6 +122,7 @@ class WinAuthenticator(LocalAuthenticator):
             return None
         return {
             'name': data['username'],
+            'domain': domain,
             'auth_state': {
                 # Detach so the underlying winhandle stays alive
                 'auth_token': token.Detach(),

--- a/winauthenticator/winauthenticator.py
+++ b/winauthenticator/winauthenticator.py
@@ -27,15 +27,7 @@ class WinAuthenticator(LocalAuthenticator):
     open_sessions = Bool(True,
                          help="""
         Whether to load a user profile when spawners are started.
-        This may trigger things like creating USERPROFILE and APPDATA directories
-        If any errors are encountered when loading/unloading user profiles,
-        this is set to False if disable_open_sessions_after_failure is True.
-        """
-                        ).tag(config=True)
-
-    disable_open_sessions_after_failure = Bool(True,
-                         help="""
-        Whether to disable open_sessions after a failure.
+        This may trigger things like creating USERPROFILE and APPDATA directories.
         """
                         ).tag(config=True)
 
@@ -163,9 +155,6 @@ class WinAuthenticator(LocalAuthenticator):
             )
         except Exception as exc:
             self.log.warning("Failed to load user profile for %s: %s", user.name, exc)
-            if self.disable_open_sessions_after_failure:
-                self.log.warning("Disabling user profile from now on.")
-                self.open_sessions = False
         finally:
             if token:
                 # Detach so the underlying winhandle stays alive

--- a/winauthenticator/winauthenticator.py
+++ b/winauthenticator/winauthenticator.py
@@ -29,7 +29,13 @@ class WinAuthenticator(LocalAuthenticator):
         Whether to load a user profile when spawners are started.
         This may trigger things like creating USERPROFILE and APPDATA directories
         If any errors are encountered when loading/unloading user profiles,
-        this is automatically set to False.
+        this is set to False if disable_open_sessions_after_failure is True.
+        """
+                        ).tag(config=True)
+
+    disable_open_sessions_after_failure = Bool(True,
+                         help="""
+        Whether to disable open_sessions after a failure.
         """
                         ).tag(config=True)
 
@@ -147,8 +153,9 @@ class WinAuthenticator(LocalAuthenticator):
             )
         except Exception as exc:
             self.log.warning("Failed to load user profile for %s: %s", user.name, exc)
-            self.log.warning("Disabling user profile from now on.")
-            self.open_sessions = False
+            if self.disable_open_sessions_after_failure:
+                self.log.warning("Disabling user profile from now on.")
+                self.open_sessions = False
         finally:
             if token:
                 # Detach so the underlying winhandle stays alive


### PR DESCRIPTION
I dislike the current behaviour that disables open_sessions after a failure.

I have found that after restarting jupyter_hub, users already logged in can't start a server, because of a stale token issue - they get an error 500. Furthermore, this disables open_sessions which means the server now needs restarting.

So I added the disable_open_sessions_after_failure config option, which I set to False in my config.  The users need to logout and login again to bypass the stale token issue.

To be honest, I'd rather remove the behaviour that disables open_sessions - people that do not need open_sessions  can already disable open_sessions. But if there's a case for keeping it, this is a PR that enables both uses.